### PR TITLE
Revert "Use a cookie instead of a query param for wcmmode"

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -15,11 +15,6 @@ input {
   height: 14px;
 }
 
-textarea {
-  width: 100%;
-  height: 150px;
-}
-
 a {
   color: #2b9af3;
   text-decoration: none;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,27 +1,31 @@
 {
-   "background": {
-      "scripts": [ "background.js" ]
-   },
-   "browser_action": {
-      "default_icon": {
-         "19": "images/icon19.png",
-         "38": "images/icon38.png"
-      },
-      "default_popup": "popup.html",
-      "default_title": "AEM Developer"
-   },
-   "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'",
-   "description": "Tools for AEM developers.",
-   "homepage_url": "https://github.com/nateyolles/aem-developer-chrome/",
-   "icons": {
-      "128": "images/icon128.png",
-      "16": "images/icon16.png",
-      "48": "images/icon48.png"
-   },
-   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAgQAaVZNFeKhzLEKrxctYHoHIveeVkNE73LKQbEzPBhp0UJm7ofjDcPC/k7r9WrkBith3I4Mwvvo0Ujjq78olb0j/qDF6T/SPJX9VPsJAbXwunO6pgkIUD6JLyYPc1l2PmomxWVTm3xsd+LvPZh/VKSGI4VdKbq3fqYMdUQbTY3xAwosMkHeQu40VEztsHU4czr2ea3snOFSIstpy4eqnMJvA95cCfSPxmCa+BWzCZVxTj6/CqbI/c/E+edG059h+RE2XloJ+tBGODxWpTfJfBpamj2G0vJapY/SnP6c4Sz+tQVqA0g19Rhy4NovYFrz/yDeYLgeWVhDMdjZ0t0AlhwIDAQAB",
-   "manifest_version": 2,
-   "name": "AEM Developer",
-   "permissions": [ "tabs", "cookies", "notifications", "http://*/*", "https://*/*" ],
-   "update_url": "https://clients2.google.com/service/update2/crx",
-   "version": "0.3.1"
+  "manifest_version": 2,
+
+  "name": "AEM Developer",
+  "version": "0.3.1",
+  "description": "Tools for AEM developers.",
+  "homepage_url": "https://github.com/nateyolles/aem-developer-chrome/",
+
+  "icons": {
+    "16" : "images/icon16.png",
+    "48" : "images/icon48.png",
+    "128" : "images/icon128.png"
+  },
+
+  "browser_action": {
+    "default_icon": {
+      "19": "images/icon19.png",
+      "38": "images/icon38.png"
+    },
+    "default_title": "AEM Developer",
+    "default_popup": "popup.html"
+  },
+
+  "background": {
+    "scripts": ["background.js"]
+  },
+
+  "permissions": ["tabs", "notifications", "http://*/*", "https://*/*"],
+
+  "content_security_policy": "script-src 'self' https://ssl.google-analytics.com; object-src 'self'"
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -68,10 +68,10 @@
                         <h3>WCM Mode</h3>
                         <div class="content">
                             <div class="btn-group">
-                                <button class="wcmmode" data-wcmmode="disabled">Disabled</button>
-                                <button class="wcmmode" data-wcmmode="edit">Edit</button>
-                                <button class="wcmmode" data-wcmmode="design">Design</button>
-                                <button class="wcmmode" data-wcmmode="preview">Preview</button>
+                                <button class="querystring" data-querystring-key="wcmmode" data-querystring-value="disabled">Disabled</button>
+                                <button class="querystring" data-querystring-key="wcmmode" data-querystring-value="edit">Edit</button>
+                                <button class="querystring" data-querystring-key="wcmmode" data-querystring-value="design">Design</button>
+                                <button class="querystring" data-querystring-key="wcmmode" data-querystring-value="preview">Preview</button>
                             </div>
                         </div>
                     </li>
@@ -141,20 +141,17 @@
                     </li>
                 </ul>
                 <ul class="sublist environments" data-ng-show="collapseA">
-                    <li data-ng-repeat="server in options.servers" data-ng-show="ServersForm.isMode('edit')" class="input-container">
+                    <li data-ng-repeat="server in options.servers" data-ng-show="editMode" class="input-container">
                         <input placeholder="name" data-ng-model="server.name">
                         <input placeholder="url" data-ng-model="server.url">
                         <i data-ng-click="remove()" class="icon-minus"></i>
                     </li>
-                    <li data-ng-show="ServersForm.isMode('edit')" class="input-container">
-                        <input placeholder="name" data-ng-model="ServersForm.newServer.name" required>
-                        <input placeholder="url" data-ng-model="ServersForm.newServer.url" required>
+                    <li data-ng-show="editMode" class="input-container">
+                        <input placeholder="name" data-ng-model="newServer.name" required>
+                        <input placeholder="url" data-ng-model="newServer.url" required>
                         <i data-ng-click="add()" class="icon-plus"></i>
                     </li>
-                    <li data-ng-show="ServersForm.isMode('import')">
-                      <textarea data-ng-model="ServersForm.serversJson" class=""></textarea>
-                    </li>
-                    <li data-ng-repeat="server in options.servers" data-ng-show="ServersForm.isMode('view')">
+                    <li data-ng-repeat="server in options.servers" data-ng-show="!editMode">
                         <a href="" ng-click="redirectToEnvironment(false)" title="open same page in {{server.name}}" data-ng-bind="server.name"></a>
                         <a href="" ng-click="redirectToEnvironment(true)" title="open same page in {{server.name}} in new window" class="new-window">
                             <i class="icon-link-external"></i>
@@ -166,12 +163,8 @@
                             <button ng-click="compareToEnvironment(true)" id="compare_{{$index}}"><i class="icon-file-empty"></i> View</button>
                         </div>
                     </li>
-                    <li class="edit" data-ng-show="ServersForm.isMode('view')">
-                        <a data-ng-click="ServersForm.changeToImport()" title="import servers as JSON">Import <i class="icon-pencil"></i></a>|
-                        <a data-ng-click="ServersForm.changeToEdit()" title="add, edit and remove servers">Edit <i class="icon-pencil"></i></a>
-                    </li>
-                    <li class="edit" data-ng-show="ServersForm.isMode('edit')"><a data-ng-click="ServersForm.saveEditChanges()" title="save servers">Done <i class="icon-disk"></i></a></li>
-                    <li class="edit" data-ng-show="ServersForm.isMode('import')"><a data-ng-click="ServersForm.saveImportChanges()" title="save servers">Done <i class="icon-disk"></i></a></li>
+                    <li class="edit" data-ng-show="!editMode"><a data-ng-click="changeEditMode()" title="add, edit and remove servers">Edit <i class="icon-pencil"></i></a></li>
+                    <li class="edit" data-ng-show="editMode"><a data-ng-click="changeEditMode()" title="save servers">Done <i class="icon-disk"></i></a></li>
                 </ul>
             </section>
 


### PR DESCRIPTION
Reverts nateyolles/aem-developer-chrome#16

Broke functionality. Add and Remove in edit no longer work. You should be able to:
1) click edit, enter a name and url, click + to save
2) click edit, click - to remove an entry and save
3) click edit, enter a name and url, without clicking +, click done to save

I like where this is going, let's just fix the lost functionality. I would also suggest one goal per pull request.